### PR TITLE
Refactor store session data

### DIFF
--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -33,11 +33,13 @@ export class AuthComponent implements OnInit, OnDestroy {
   isAppOutdated: boolean;
   versionCheckingError: boolean;
 
+  sessionSelected: string;
   authState: AuthState;
   accessTokenSubscription: Subscription;
   authStateSubscription: Subscription;
   profileForm: FormGroup;
   currentUserName: string;
+  noSessionSelected = "No session selected";
 
   constructor(public appService: ApplicationService,
               public electronService: ElectronService,
@@ -170,6 +172,7 @@ export class AuthComponent implements OnInit, OnDestroy {
    */
   onProfileSelect(profile: Profile): void {
     this.profileForm.get('session').setValue(profile.encodedText);
+    this.sessionSelected = profile.profileName;
   }
 
   /**
@@ -201,10 +204,7 @@ export class AuthComponent implements OnInit, OnDestroy {
     const dataRepo: string = this.getDataRepoDetails(sessionInformation);
     this.githubService.storeOrganizationDetails(org, dataRepo);
 
-    this.phaseService.storeSessionData().pipe(
-      throwIfFalse(isValidSession => isValidSession,
-                   () => new Error('Invalid Session'))
-    ).subscribe(() => {
+    this.phaseService.storeSessionData().subscribe(() => {
       try {
         this.authService.startOAuthProcess();
       } catch (error) {

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -33,13 +33,11 @@ export class AuthComponent implements OnInit, OnDestroy {
   isAppOutdated: boolean;
   versionCheckingError: boolean;
 
-  sessionSelected: string;
   authState: AuthState;
   accessTokenSubscription: Subscription;
   authStateSubscription: Subscription;
   profileForm: FormGroup;
   currentUserName: string;
-  noSessionSelected = "No session selected";
 
   constructor(public appService: ApplicationService,
               public electronService: ElectronService,
@@ -172,7 +170,6 @@ export class AuthComponent implements OnInit, OnDestroy {
    */
   onProfileSelect(profile: Profile): void {
     this.profileForm.get('session').setValue(profile.encodedText);
-    this.sessionSelected = profile.profileName;
   }
 
   /**

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -74,12 +74,11 @@ export class PhaseService {
    * Will fetch session data and update phase service with it.
    * @returns - If the session is valid return true, else false
    */
-  storeSessionData(): Observable<boolean> {
+  storeSessionData(): Observable<void> {
     return this.fetchSessionData().pipe(
       assertSessionDataIntegrity(),
       map((sessionData: SessionData) => {
         this.updateSessionParameters(sessionData);
-        return this.currentPhase !== undefined;
       })
     );
   }

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -72,7 +72,6 @@ export class PhaseService {
 
   /**
    * Will fetch session data and update phase service with it.
-   * @returns - If the session is valid return true, else false
    */
   storeSessionData(): Observable<void> {
     return this.fetchSessionData().pipe(

--- a/tests/services/phase.service.spec.ts
+++ b/tests/services/phase.service.spec.ts
@@ -19,17 +19,17 @@ describe('PhaseService', () => {
   });
 
   describe('.storeSessionData()', () => {
-    it('should return an Observable of true if an openPhase is defined', () => {
+    it('should return an Observable of void if an openPhase is defined', () => {
       githubService.fetchSettingsFile.and.returnValue(of(BUG_REPORTING_PHASE_SESSION_DATA));
-      phaseService.storeSessionData().subscribe((result: boolean) => {
-        expect(result).toBeTrue();
+      phaseService.storeSessionData().subscribe((result: void) => {
+        expect().nothing();
       });
     });
 
-    it('should return an Observable of true if multiple openPhases are defined', () => {
+    it('should return an Observable of void if multiple openPhases are defined', () => {
       githubService.fetchSettingsFile.and.returnValue(of(MULTIPLE_OPEN_PHASES_SESSION_DATA));
-      phaseService.storeSessionData().subscribe((result: boolean) => {
-        expect(result).toBeTrue();
+      phaseService.storeSessionData().subscribe((result: void) => {
+        expect().nothing();
       });
     });
 


### PR DESCRIPTION
My attempt at addressing issue #595.

Removed the line `return this.currentPhase !== undefined` as it appears that assertSessionDataIntegrity() does the validation now.

Also removed the pipe performed on `PhaseService` as the method no longer returns a boolean value. As noted in PR #586 comment, it appears that an invalid open phase name will be caught by `assertSessionDataIntegrity()` now instead of  `PhaseService`, hence the removal of the pipe.

Left the subscribe method intact so that ` this.authService.startOAuthProcess();` will occur once the `updateSessionParameters` are completed. Also updated the according test files



